### PR TITLE
Better handling of no comments

### DIFF
--- a/views/partials/comments.handlebars
+++ b/views/partials/comments.handlebars
@@ -30,6 +30,10 @@
         <button type="submit" class="btn btn-primary">add comment</button>
       </div>
     </form>
+    {{else}}
+    {{#unless comments}}
+    <p class="p-1 text-muted"><em>No comments.</em></p>
+    {{/unless}}
     {{/if}}
   </div>
 </section>


### PR DESCRIPTION
Instead of an empty comments box, show a "no comments" message.