### PR TITLE
Bug fix: fix redirect on sign-up

### DIFF
--- a/public/javascript/login.js
+++ b/public/javascript/login.js
@@ -17,7 +17,7 @@ async function signupFormHandler(event) {
     });
 
     if (response.ok) {
-      document.location.replace('nextUrl');
+      document.location.replace(nextUrl);
     } else {
       alert(response.statusText);
     }


### PR DESCRIPTION
Redirect after sign up was using the variable name (as a string) instead of the variable value.